### PR TITLE
Support non-JSON messages

### DIFF
--- a/src/amqp.coffee
+++ b/src/amqp.coffee
@@ -109,7 +109,7 @@ class Client extends interfaces.MessagingClient
       try
         data = JSON.parse message.content.toString()
       catch e
-        debug 'JSON exception:', e
+        data = message.content.toString()
       out =
         amqp: message
         data: data

--- a/src/mqtt.coffee
+++ b/src/mqtt.coffee
@@ -75,7 +75,7 @@ class Client extends interfaces.MessagingClient
     try
       msg = JSON.parse message.toString()
     catch e
-      debug 'JSON parse exception:', e
+      msg = message.toString()
     handlers = @subscribers[topic]
 
     debug 'message', handlers.length, msg != null


### PR DESCRIPTION
When dealing with foreign participants it is quite common that the messages are not JSON.