### PR TITLE
WIP| mqtt: Update to version 2.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-mocha-test": "^0.12.2",
     "grunt-shell-spawn": "^0.3.1",
     "mocha": "~1.21.0",
-    "mqtt": "^1.4.0"
+    "mqtt": "^2.0.0"
   },
   "keywords": [],
   "bin": {


### PR DESCRIPTION
Need to test/document how to support old 3.1-only MQTT brokers before merging. And probably should do a bit of real-life tests
